### PR TITLE
Fix rescue => e

### DIFF
--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -20,7 +20,10 @@ if __FILE__ == $0
   end
 
   # Ensure the server has time to start
-  sleep 1
+  sleep 0
+
+  # Tell the cron_thread how often it should fire
+  MyApp.cron_interval = CacheHelpers::CACHE_DURATION
 
   # Start background threads
   MyApp.start_threads

--- a/ruby/modules/cache_helpers.rb
+++ b/ruby/modules/cache_helpers.rb
@@ -49,7 +49,7 @@ module CacheHelpers
         erro("Error fetching data: #{response.code} #{response.message}")
         nil
       end
-    rescue => e
+    rescue StandardError => e
       erro("Exception while fetching data: #{e.message}")
       nil
     end
@@ -77,7 +77,7 @@ module CacheHelpers
       end
 
       true
-    rescue => e
+    rescue StandardError => e
       erro("Error checking cache readiness: #{e.message}")
       false
     end

--- a/ruby/modules/my_app.rb
+++ b/ruby/modules/my_app.rb
@@ -30,7 +30,7 @@ class MyApp < Sinatra::Base
       body "Cache is updating, please try again later."
     end
     # log_request(request: request, response: response, data_sent: false, compressed: false)
-  rescue => e
+  rescue StandardError => e
     settings.state_manager.increment_error_count
     handle_data_error(e)
   end
@@ -61,7 +61,7 @@ class MyApp < Sinatra::Base
     end
 
     serve_appropriate_response
-  rescue => e
+  rescue StandardError => e
     handle_serve_error(e)
   end
 
@@ -126,7 +126,7 @@ class MyApp < Sinatra::Base
 
     status 202
     body "Cache is updating, please try again later."
-  rescue => e
+  rescue StandardError => e
     erro("Error requesting cache update: #{e.message}")
     status 202  # Keep the 202 status even if there's an error
     body "Cache is updating, please try again later."
@@ -180,7 +180,7 @@ class MyApp < Sinatra::Base
         rescue Redis::BaseConnectionError, SocketError => e
           settings.state_manager.update_redis_status(:disconnected)
           erro("Redis health check failed: #{e.message}")
-        rescue => e
+        rescue StandardError => e
           settings.state_manager.update_redis_status(:error)
           erro("Unexpected error in Redis health check: #{e.message}")
         end
@@ -261,7 +261,7 @@ class MyApp < Sinatra::Base
       rescue Redis::BaseConnectionError, EOFError => e
         erro("Redis connection error in listener thread: #{e.message}")
         settings.state_manager.update_redis_status(:disconnected)
-      rescue => e
+      rescue StandardError => e
         erro("Failed to subscribe to Redis channel: #{e.message}")
         erro(e.backtrace.join("\n"))
         settings.state_manager.update_redis_status(:error)

--- a/ruby/modules/my_app.rb
+++ b/ruby/modules/my_app.rb
@@ -234,7 +234,7 @@ class MyApp < Sinatra::Base
       loop do
         if cache_ready?
           debu("Cache is ready, no update needed in cron_thread")
-      settings.state_manager.update_cache_status(:ready)
+          settings.state_manager.update_cache_status(:ready)
         elsif acquire_lock
           debu("Lock acquired in cron_thread, updating cache")
           update_cache


### PR DESCRIPTION
Never do `rescue => e`, as that can block `^C` from correctly halting the program, and probably a zillion other bad things